### PR TITLE
0.2.0 - Standardize inputs and execution order, improve movement speed adjustment

### DIFF
--- a/Packages/com.varneon.vudon.noclip/Noclip.prefab
+++ b/Packages/com.varneon.vudon.noclip/Noclip.prefab
@@ -9,8 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7617984235308416798}
-  - component: {fileID: 7617984235308416785}
-  - component: {fileID: 7617984235308416784}
+  - component: {fileID: 7117740436155577295}
+  - component: {fileID: 6077235003161976082}
   m_Layer: 0
   m_Name: Noclip
   m_TagString: Untagged
@@ -32,7 +32,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7617984235308416785
+--- !u!114 &7117740436155577295
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -53,16 +53,39 @@ MonoBehaviour:
     PrefabModificationsReferencedUnityObjects: []
     PrefabModifications: []
     SerializationNodes: []
-  _udonSharpBackingUdonBehaviour: {fileID: 7617984235308416784}
+  _udonSharpBackingUdonBehaviour: {fileID: 6077235003161976082}
   noclipTriggerMethod: 0
   toggleThreshold: 0.25
   speed: 15
-  vrSpeedExponent: 2
+  vrInputMultiplier:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   desktopSpeedFraction: 0.25
   desktopVerticalInput: 1
   upKey: 101
   downKey: 113
---- !u!114 &7617984235308416784
+--- !u!114 &6077235003161976082
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -81,7 +104,7 @@ MonoBehaviour:
   SynchronizePosition: 0
   AllowCollisionOwnershipTransfer: 0
   Reliable: 0
-  _syncMethod: 1
+  _syncMethod: 0
   serializedProgramAsset: {fileID: 11400000, guid: e9cf694ca30d71e42ac2f35b1ec6a93f,
     type: 2}
   programSource: {fileID: 11400000, guid: 51ead3bb0841106499e15c410ba8685c, type: 2}

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
@@ -383,7 +383,7 @@ MonoBehaviour:
       Data: 29|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
     - Name: FieldName
       Entry: 1
-      Data: Input Exponent
+      Data: Input Multiplier
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
@@ -308,19 +308,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: vrSpeedExponent
+      Data: vrInputMultiplier
     - Name: $v
       Entry: 7
       Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: vrSpeedExponent
+      Data: vrInputMultiplier
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 10
+      Entry: 7
+      Data: 23|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.AnimationCurve, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 23
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -335,41 +341,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 23|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 5
+      Data: 4
     - Name: 
       Entry: 7
-      Data: 24|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 25|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 25|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
-    - Name: tooltip
-      Entry: 1
-      Data: '[1 = Linear input curve | 1< = Exponential input curve] Helps with ''crawling''
-        slowly when just slightly moving joystick even with higher standard speed'
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 26|UnityEngine.RangeAttribute, UnityEngine.CoreModule
-    - Name: min
-      Entry: 4
-      Data: 1
-    - Name: max
-      Entry: 4
-      Data: 5
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 27|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 26|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_VR
@@ -378,10 +362,26 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 28|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
+      Data: 27|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
     - Name: FieldName
       Entry: 1
       Data: Input Exponent
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 28|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+    - Name: tooltip
+      Entry: 1
+      Data: 'Input speed multiplier curve for VR.
+
+
+        Horizontal (0-1): VR
+        movement input magnitude
+
+
+        Vertical (0-1): Speed multiplier'
     - Name: 
       Entry: 8
       Data: 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
@@ -92,16 +92,25 @@ MonoBehaviour:
       Data: 5|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 3
+      Data: 4
     - Name: 
       Entry: 7
-      Data: 6|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 6|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
+    - Name: header
+      Entry: 1
+      Data: Settings
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 7|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 7|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 8|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Method for triggering the noclip mode
@@ -110,7 +119,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 8|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 9|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Settings
@@ -137,13 +146,13 @@ MonoBehaviour:
       Data: toggleThreshold
     - Name: $v
       Entry: 7
-      Data: 9|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 10|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: toggleThreshold
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 10|System.RuntimeType, mscorlib
+      Data: 11|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Single, mscorlib
@@ -152,7 +161,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -167,19 +176,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 11|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 12|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 4
     - Name: 
       Entry: 7
-      Data: 12|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 13|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 13|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 14|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Time in which jump has to be double tapped in order to toggle noclip
@@ -188,7 +197,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 14|UnityEngine.RangeAttribute, UnityEngine.CoreModule
+      Data: 15|UnityEngine.RangeAttribute, UnityEngine.CoreModule
     - Name: min
       Entry: 4
       Data: 0.1
@@ -200,7 +209,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 15|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 16|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Settings
@@ -227,16 +236,16 @@ MonoBehaviour:
       Data: speed
     - Name: $v
       Entry: 7
-      Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 17|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: speed
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -251,19 +260,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 17|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 18|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 4
     - Name: 
       Entry: 7
-      Data: 18|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 19|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 19|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 20|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Maximum speed in m/s
@@ -272,7 +281,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 20|UnityEngine.RangeAttribute, UnityEngine.CoreModule
+      Data: 21|UnityEngine.RangeAttribute, UnityEngine.CoreModule
     - Name: min
       Entry: 4
       Data: 1
@@ -284,7 +293,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 21|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 22|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Settings
@@ -311,13 +320,13 @@ MonoBehaviour:
       Data: vrInputMultiplier
     - Name: $v
       Entry: 7
-      Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: vrInputMultiplier
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 23|System.RuntimeType, mscorlib
+      Data: 24|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.AnimationCurve, UnityEngine.CoreModule
@@ -326,7 +335,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 23
+      Data: 24
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -341,19 +350,28 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 4
+      Data: 5
     - Name: 
       Entry: 7
-      Data: 25|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 26|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
+    - Name: header
+      Entry: 1
+      Data: VR
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 26|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 27|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 28|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_VR
@@ -362,7 +380,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 27|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
+      Data: 29|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
     - Name: FieldName
       Entry: 1
       Data: Input Exponent
@@ -371,7 +389,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 28|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 30|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: 'Input speed multiplier curve for VR.
@@ -405,16 +423,16 @@ MonoBehaviour:
       Data: desktopSpeedFraction
     - Name: $v
       Entry: 7
-      Data: 29|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 31|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: desktopSpeedFraction
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -429,19 +447,28 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 30|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 5
+      Data: 6
     - Name: 
       Entry: 7
-      Data: 31|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 33|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
+    - Name: header
+      Entry: 1
+      Data: Desktop
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 32|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 34|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 35|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Speed multiplier when Shift is not pressed
@@ -450,7 +477,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 33|UnityEngine.RangeAttribute, UnityEngine.CoreModule
+      Data: 36|UnityEngine.RangeAttribute, UnityEngine.CoreModule
     - Name: min
       Entry: 4
       Data: 0.1
@@ -462,7 +489,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 34|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 37|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Desktop
@@ -471,7 +498,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 35|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
+      Data: 38|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
     - Name: FieldName
       Entry: 1
       Data: Speed Fraction
@@ -498,13 +525,13 @@ MonoBehaviour:
       Data: desktopVerticalInput
     - Name: $v
       Entry: 7
-      Data: 36|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 39|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: desktopVerticalInput
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 37|System.RuntimeType, mscorlib
+      Data: 40|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Boolean, mscorlib
@@ -513,7 +540,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -528,19 +555,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 38|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 41|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 4
     - Name: 
       Entry: 7
-      Data: 39|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 42|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 40|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 43|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Allow vertical movement on desktop
@@ -549,7 +576,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 41|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 44|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Desktop
@@ -558,7 +585,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 42|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
+      Data: 45|Varneon.VInspector.FieldLabelAttribute, Varneon.V-Inspector.Runtime
     - Name: FieldName
       Entry: 1
       Data: Allow Vertical Input
@@ -585,13 +612,13 @@ MonoBehaviour:
       Data: upKey
     - Name: $v
       Entry: 7
-      Data: 43|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 46|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: upKey
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
+      Data: 47|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.KeyCode, UnityEngine.CoreModule
@@ -600,7 +627,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 47
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -615,19 +642,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 3
     - Name: 
       Entry: 7
-      Data: 46|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 49|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 47|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 50|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Key for ascending on desktop
@@ -636,7 +663,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 48|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 51|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Desktop
@@ -663,16 +690,16 @@ MonoBehaviour:
       Data: downKey
     - Name: $v
       Entry: 7
-      Data: 49|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 52|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: downKey
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 47
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 44
+      Data: 47
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -687,19 +714,19 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 50|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 53|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 3
     - Name: 
       Entry: 7
-      Data: 51|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 54|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
     - Name: 
       Entry: 7
-      Data: 52|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
+      Data: 55|UnityEngine.TooltipAttribute, UnityEngine.CoreModule
     - Name: tooltip
       Entry: 1
       Data: Key for descending on desktop
@@ -708,7 +735,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 7
-      Data: 53|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
+      Data: 56|Varneon.VInspector.FieldParentElementAttribute, Varneon.V-Inspector.Runtime
     - Name: ParentName
       Entry: 1
       Data: Foldout_Desktop
@@ -735,16 +762,16 @@ MonoBehaviour:
       Data: toggleByDoubleJump
     - Name: $v
       Entry: 7
-      Data: 54|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 57|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: toggleByDoubleJump
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -759,7 +786,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 55|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 58|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -783,16 +810,16 @@ MonoBehaviour:
       Data: noclipEnabled
     - Name: $v
       Entry: 7
-      Data: 56|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 59|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: noclipEnabled
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -807,7 +834,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 57|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 60|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -831,70 +858,16 @@ MonoBehaviour:
       Data: switchPrimed
     - Name: $v
       Entry: 7
-      Data: 58|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 61|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: switchPrimed
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 40
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 37
-    - Name: <SyncMode>k__BackingField
-      Entry: 7
-      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
-    - Name: 
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <IsSerialized>k__BackingField
-      Entry: 5
-      Data: false
-    - Name: _fieldAttributes
-      Entry: 7
-      Data: 59|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: position
-    - Name: $v
-      Entry: 7
-      Data: 60|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: <Name>k__BackingField
-      Entry: 1
-      Data: position
-    - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 61|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Vector3, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: <SystemType>k__BackingField
-      Entry: 9
-      Data: 61
+      Data: 40
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -930,19 +903,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: lastPosition
+      Data: position
     - Name: $v
       Entry: 7
       Data: 63|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: lastPosition
+      Data: position
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 61
+      Entry: 7
+      Data: 64|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 61
+      Data: 64
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -957,7 +936,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 64|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 65|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -978,25 +957,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: localPlayer
+      Data: lastPosition
     - Name: $v
       Entry: 7
-      Data: 65|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 66|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: localPlayer
+      Data: lastPosition
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 66|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: VRC.SDKBase.VRCPlayerApi, VRCSDKBase
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 64
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 66
+      Data: 64
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1032,19 +1005,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: vrEnabled
+      Data: localPlayer
     - Name: $v
       Entry: 7
       Data: 68|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: vrEnabled
+      Data: localPlayer
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 37
+      Entry: 7
+      Data: 69|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.SDKBase.VRCPlayerApi, VRCSDKBase
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 37
+      Data: 69
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1059,7 +1038,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 69|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 70|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1080,25 +1059,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: playerCollider
+      Data: vrEnabled
     - Name: $v
       Entry: 7
-      Data: 70|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 71|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: playerCollider
+      Data: vrEnabled
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 71|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Collider[], UnityEngine.PhysicsModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 40
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 71
+      Data: 40
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1134,19 +1107,73 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: inputMoveHorizontal
+      Data: playerCollider
     - Name: $v
       Entry: 7
       Data: 73|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
+      Data: playerCollider
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 74|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Collider[], UnityEngine.PhysicsModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 74
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 75|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: inputMoveHorizontal
+    - Name: $v
+      Entry: 7
+      Data: 76|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
       Data: inputMoveHorizontal
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1161,7 +1188,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 74|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 77|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1185,16 +1212,16 @@ MonoBehaviour:
       Data: inputMoveVertical
     - Name: $v
       Entry: 7
-      Data: 75|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 78|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: inputMoveVertical
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1209,7 +1236,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 76|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 79|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1233,16 +1260,16 @@ MonoBehaviour:
       Data: inputLookVertical
     - Name: $v
       Entry: 7
-      Data: 77|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 80|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: inputLookVertical
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 10
+      Data: 11
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1257,7 +1284,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 78|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 81|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 16
+      Data: 19
     - Name: 
       Entry: 7
       Data: 
@@ -1114,6 +1114,150 @@ MonoBehaviour:
     - Name: _fieldAttributes
       Entry: 7
       Data: 72|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: inputMoveHorizontal
+    - Name: $v
+      Entry: 7
+      Data: 73|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: inputMoveHorizontal
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 74|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: inputMoveVertical
+    - Name: $v
+      Entry: 7
+      Data: 75|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: inputMoveVertical
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 76|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: inputLookVertical
+    - Name: $v
+      Entry: 7
+      Data: 77|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: inputLookVertical
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 10
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 78|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -342,18 +342,12 @@ namespace Varneon.VUdon.Noclip
 
         public override void InputMoveHorizontal(float value, UdonInputEventArgs args)
         {
-            if (noclipEnabled)
-            {
-                inputMoveHorizontal = value;
-            }
+            inputMoveHorizontal = value;
         }
 
         public override void InputMoveVertical(float value, UdonInputEventArgs args)
         {
-            if (noclipEnabled)
-            {
-                inputMoveVertical = value;
-            }
+            inputMoveVertical = value;
         }
 
         public override void InputLookVertical(float value, UdonInputEventArgs args)

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -20,6 +20,7 @@ namespace Varneon.VUdon.Noclip
         /// <summary>
         /// Methdod for triggering noclip
         /// </summary>
+        [Header("Settings")]
         [SerializeField]
         [Tooltip("Method for triggering the noclip mode")]
         [FieldParentElement("Foldout_Settings")]
@@ -46,6 +47,7 @@ namespace Varneon.VUdon.Noclip
         /// <summary>
         /// Input speed multiplier curve for VR
         /// </summary>
+        [Header("VR")]
         [SerializeField]
         [FieldParentElement("Foldout_VR")]
         [FieldLabel("Input Exponent")]
@@ -55,6 +57,7 @@ namespace Varneon.VUdon.Noclip
         /// <summary>
         /// Speed multiplier when Shift is not pressed
         /// </summary>
+        [Header("Desktop")]
         [SerializeField]
         [Tooltip("Speed multiplier when Shift is not pressed")]
         [Range(0.1f, 1f)]

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -273,11 +273,6 @@ namespace Varneon.VUdon.Noclip
             {
                 // Apply the remainder velocity from last lerp to the player's velocity to allow them to fly after turning off noclip
                 localPlayer.SetVelocity((position - lastPosition) / Time.deltaTime);
-
-                // Reset the input values
-                inputMoveHorizontal = 0f;
-                inputMoveVertical = 0f;
-                inputLookVertical = 0f;
             }
         }
         #endregion

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -12,6 +12,7 @@ namespace Varneon.VUdon.Noclip
     /// Simple noclip
     /// </summary>
     [SelectionBase]
+    [DefaultExecutionOrder(-1000000000)]
     [HelpURL("https://github.com/Varneon/VUdon-Noclip/wiki/Settings")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Noclip : UdonSharpBehaviour

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -51,7 +51,7 @@ namespace Varneon.VUdon.Noclip
         [Header("VR")]
         [SerializeField]
         [FieldParentElement("Foldout_VR")]
-        [FieldLabel("Input Exponent")]
+        [FieldLabel("Input Multiplier")]
         [Tooltip("Input speed multiplier curve for VR.\n\nHorizontal (0-1): VR movement input magnitude\n\nVertical (0-1): Speed multiplier")]
         private AnimationCurve vrInputMultiplier = new AnimationCurve(new Keyframe(0f, 0f, 0f, 0f), new Keyframe(1f, 1f, 2f, 2f));
 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -13,6 +13,7 @@ namespace Varneon.VUdon.Noclip
     /// Simple noclip
     /// </summary>
     [SelectionBase]
+    [HelpURL("https://github.com/Varneon/VUdon-Noclip/wiki/Settings")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Noclip : UdonSharpBehaviour
     {

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -207,7 +207,7 @@ namespace Varneon.VUdon.Noclip
                     float deltaTimeMaxSpeed = deltaTime * (Input.GetKey(KeyCode.LeftShift) ? speed : speed * desktopSpeedFraction);
 
                     // Apply the position changes from vertical and horizontal inputs
-                    position += headRot * (new Vector3(inputMoveHorizontal, 0f, inputMoveVertical) * deltaTimeMaxSpeed);
+                    position += headRot * (new Vector3(inputMoveHorizontal, 0f, inputMoveVertical).normalized * deltaTimeMaxSpeed);
 
                     // If allowed, apply vertical motion
                     if (desktopVerticalInput)

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -271,6 +271,11 @@ namespace Varneon.VUdon.Noclip
             {
                 // Apply the remainder velocity from last lerp to the player's velocity to allow them to fly after turning off noclip
                 localPlayer.SetVelocity((position - lastPosition) / Time.deltaTime);
+
+                // Reset the input values
+                inputMoveHorizontal = 0f;
+                inputMoveVertical = 0f;
+                inputLookVertical = 0f;
             }
         }
         #endregion

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -257,6 +257,8 @@ namespace Varneon.VUdon.Noclip
         /// <param name="enabled"></param>
         private void SetNoclipEnabled(bool enabled)
         {
+            if (noclipEnabled == enabled) { return; }
+
             noclipEnabled = enabled;
 
             localPlayer.Immobilize(enabled);

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -108,7 +108,7 @@ namespace Varneon.VUdon.Noclip
         /// Current position of the player
         /// </summary>
         private Vector3 position;
-        
+
         /// <summary>
         /// Last position of the player
         /// </summary>
@@ -132,10 +132,20 @@ namespace Varneon.VUdon.Noclip
         /// </summary>
         private Collider[] playerCollider = new Collider[1];
 
-        private const string
-            AXIS_HORIZONTAL = "Horizontal",
-            AXIS_VERTICAL = "Vertical",
-            AXIS_RIGHT_THUMBSTICK_VERTICAL = "Oculus_CrossPlatform_SecondaryThumbstickVertical";
+        /// <summary>
+        /// Current horizontal move input
+        /// </summary>
+        private float inputMoveHorizontal;
+
+        /// <summary>
+        /// Current vertical move input
+        /// </summary>
+        private float inputMoveVertical;
+
+        /// <summary>
+        /// Current vertical look input
+        /// </summary>
+        private float inputLookVertical;
         #endregion // Private Variables
 
         #region Unity Methods
@@ -172,26 +182,19 @@ namespace Varneon.VUdon.Noclip
 
                 float deltaTime = Time.deltaTime;
 
-                float vertical = Input.GetAxisRaw(AXIS_VERTICAL);
-
-                float horizontal = Input.GetAxisRaw(AXIS_HORIZONTAL);
-
                 if (vrEnabled)
                 {
                     // Get magnitude of the movement input to apply shared exponential velocity
-                    float exponentialInputMagnitude = Mathf.Pow(new Vector2(horizontal, vertical).magnitude, vrSpeedExponent);
-
-                    // Get the vertical input from the right joystick
-                    float worldVertical = Input.GetAxisRaw(AXIS_RIGHT_THUMBSTICK_VERTICAL);
+                    float exponentialInputMagnitude = Mathf.Pow(new Vector2(inputMoveHorizontal, inputMoveVertical).magnitude, vrSpeedExponent);
 
                     // Get the maximum delta magnitude
                     float deltaTimeSpeed = deltaTime * speed;
 
                     // Create a delta vector for local X and Z axes
-                    Vector3 xzDelta = deltaTimeSpeed * exponentialInputMagnitude * new Vector3(horizontal, 0f, vertical);
+                    Vector3 xzDelta = deltaTimeSpeed * exponentialInputMagnitude * new Vector3(inputMoveHorizontal, 0f, inputMoveVertical);
 
                     // Create a delta vector for world Y axis
-                    Vector3 yWorldDelta = new Vector3(0f, Mathf.Pow(Mathf.Abs(worldVertical), vrSpeedExponent) * Mathf.Sign(worldVertical) * deltaTimeSpeed, 0f);
+                    Vector3 yWorldDelta = new Vector3(0f, Mathf.Pow(Mathf.Abs(inputLookVertical), vrSpeedExponent) * Mathf.Sign(inputLookVertical) * deltaTimeSpeed, 0f);
 
                     // Apply the position changes
                     position += headRot * xzDelta + yWorldDelta;
@@ -204,7 +207,7 @@ namespace Varneon.VUdon.Noclip
                     float deltaTimeMaxSpeed = deltaTime * (Input.GetKey(KeyCode.LeftShift) ? speed : speed * desktopSpeedFraction);
 
                     // Apply the position changes from vertical and horizontal inputs
-                    position += headRot * (new Vector3(horizontal, 0f, vertical) * deltaTimeMaxSpeed);
+                    position += headRot * (new Vector3(inputMoveHorizontal, 0f, inputMoveVertical) * deltaTimeMaxSpeed);
 
                     // If allowed, apply vertical motion
                     if (desktopVerticalInput)
@@ -309,6 +312,30 @@ namespace Varneon.VUdon.Noclip
                         SendCustomEventDelayedSeconds(nameof(_DisablePriming), toggleThreshold);
                     }
                 }
+            }
+        }
+
+        public override void InputMoveHorizontal(float value, UdonInputEventArgs args)
+        {
+            if (noclipEnabled)
+            {
+                inputMoveHorizontal = value;
+            }
+        }
+
+        public override void InputMoveVertical(float value, UdonInputEventArgs args)
+        {
+            if (noclipEnabled)
+            {
+                inputMoveVertical = value;
+            }
+        }
+
+        public override void InputLookVertical(float value, UdonInputEventArgs args)
+        {
+            if (noclipEnabled && vrEnabled)
+            {
+                inputLookVertical = value;
             }
         }
 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -5,6 +5,7 @@ using Varneon.VUdon.Noclip.Enums;
 using Varneon.VInspector;
 using VRC.SDKBase;
 using VRC.Udon.Common;
+using VRC.Udon.Common.Enums;
 
 namespace Varneon.VUdon.Noclip
 {
@@ -145,6 +146,11 @@ namespace Varneon.VUdon.Noclip
         /// Current vertical look input
         /// </summary>
         private float inputLookVertical;
+
+        /// <summary>
+        /// The event timing for late update
+        /// </summary>
+        private const EventTiming LATE_UPDATE_EVENT_TIMING = EventTiming.LateUpdate;
         #endregion // Private Variables
 
         #region Unity Methods
@@ -157,7 +163,7 @@ namespace Varneon.VUdon.Noclip
             toggleByDoubleJump = noclipTriggerMethod == NoclipTriggerMethod.DoubleJump;
         }
 
-        private void LateUpdate()
+        public void _LateUpdate()
         {
             if (noclipEnabled)
             {
@@ -229,6 +235,8 @@ namespace Varneon.VUdon.Noclip
 
                 // Force the player's velocity to zero to prevent the falling animation from triggering
                 localPlayer.SetVelocity(Vector3.zero);
+
+                CueLateUpdate();
             }
         }
         #endregion
@@ -263,6 +271,8 @@ namespace Varneon.VUdon.Noclip
             {
                 // Get the initial position of the player
                 position = localPlayer.GetPosition();
+
+                CueLateUpdate();
             }
             else
             {
@@ -274,6 +284,14 @@ namespace Varneon.VUdon.Noclip
                 inputMoveVertical = 0f;
                 inputLookVertical = 0f;
             }
+        }
+
+        /// <summary>
+        /// Cues late update event for next frame
+        /// </summary>
+        private void CueLateUpdate()
+        {
+            SendCustomEventDelayedFrames(nameof(_LateUpdate), 0, LATE_UPDATE_EVENT_TIMING);
         }
         #endregion
 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -197,6 +197,15 @@ namespace Varneon.VUdon.Noclip
 
                     // Apply the position changes
                     position += headRot * xzDelta + yWorldDelta;
+
+                    // Get the player's playspace origin tracking data
+                    VRCPlayerApi.TrackingData originData = localPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Origin);
+
+                    // Get the playspace delta for applying to the final position
+                    Vector3 playspaceDelta = originData.position - localPlayerPos;
+
+                    // If the player is in VR, use the origin's rotation instead of player's rotation and align the room with spawn point
+                    localPlayer.TeleportTo(position + playspaceDelta, originData.rotation, VRC_SceneDescriptor.SpawnOrientation.AlignRoomWithSpawnPoint, true);
                 }
                 else
                 {
@@ -213,20 +222,8 @@ namespace Varneon.VUdon.Noclip
                     {
                         position += new Vector3(0f, deltaTimeMaxSpeed * worldVertical, 0f);
                     }
-                }
 
-                if (vrEnabled)
-                {
-                    VRCPlayerApi.TrackingData originData = localPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Origin);
-
-                    // Get the playspace delta for applying to the final position
-                    Vector3 playspaceDelta = originData.position - localPlayerPos;
-
-                    // If the player is in VR, use the origin's rotation instead of player's rotation and align the room with spawn point
-                    localPlayer.TeleportTo(position + playspaceDelta, originData.rotation, VRC_SceneDescriptor.SpawnOrientation.AlignRoomWithSpawnPoint, true);
-                }
-                else
-                {
+                    // Teleport player to the new position
                     localPlayer.TeleportTo(position, localPlayer.GetRotation(), VRC_SceneDescriptor.SpawnOrientation.Default, true);
                 }
 

--- a/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
+++ b/Packages/com.varneon.vudon.noclip/Runtime/Udon Programs/Noclip.cs
@@ -5,7 +5,6 @@ using Varneon.VUdon.Noclip.Enums;
 using Varneon.VInspector;
 using VRC.SDKBase;
 using VRC.Udon.Common;
-using VRC.Udon.Common.Enums;
 
 namespace Varneon.VUdon.Noclip
 {
@@ -150,11 +149,6 @@ namespace Varneon.VUdon.Noclip
         /// Current vertical look input
         /// </summary>
         private float inputLookVertical;
-
-        /// <summary>
-        /// The event timing for late update
-        /// </summary>
-        private const EventTiming LATE_UPDATE_EVENT_TIMING = EventTiming.LateUpdate;
         #endregion // Private Variables
 
         #region Unity Methods
@@ -167,7 +161,7 @@ namespace Varneon.VUdon.Noclip
             toggleByDoubleJump = noclipTriggerMethod == NoclipTriggerMethod.DoubleJump;
         }
 
-        public void _LateUpdate()
+        private void LateUpdate()
         {
             if (noclipEnabled)
             {
@@ -239,8 +233,6 @@ namespace Varneon.VUdon.Noclip
 
                 // Force the player's velocity to zero to prevent the falling animation from triggering
                 localPlayer.SetVelocity(Vector3.zero);
-
-                CueLateUpdate();
             }
         }
         #endregion
@@ -275,8 +267,6 @@ namespace Varneon.VUdon.Noclip
             {
                 // Get the initial position of the player
                 position = localPlayer.GetPosition();
-
-                CueLateUpdate();
             }
             else
             {
@@ -288,14 +278,6 @@ namespace Varneon.VUdon.Noclip
                 inputMoveVertical = 0f;
                 inputLookVertical = 0f;
             }
-        }
-
-        /// <summary>
-        /// Cues late update event for next frame
-        /// </summary>
-        private void CueLateUpdate()
-        {
-            SendCustomEventDelayedFrames(nameof(_LateUpdate), 0, LATE_UPDATE_EVENT_TIMING);
         }
         #endregion
 

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.1",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "com.vrchat.udonsharp": "1.0.1",
-    "com.varneon.neon-inspector": "0.0.1"
+    "com.varneon.neon-inspector": "0.0.2"
   },
   "vpmDependencies": {
     "com.vrchat.udonsharp": "1.x.x",
-    "com.varneon.neon-inspector": "0.0.1"
+    "com.varneon.neon-inspector": ">=0.0.2 <1.0.0"
   },
   "resolutionStrategy": "highestMinor"
 }

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -16,5 +16,6 @@
   "vpmDependencies": {
     "com.vrchat.udonsharp": "1.x.x",
     "com.varneon.neon-inspector": "0.0.1"
-  }
+  },
+  "resolutionStrategy": "highestMinor"
 }

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.2.0",
+  "version": "0.2.0-beta.3",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/Packages/com.varneon.vudon.noclip/package.json
+++ b/Packages/com.varneon.vudon.noclip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.vudon.noclip",
   "displayName": "VUdon - Noclip",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "unity": "2019.4",
   "unityRelease": "29f1",
   "description": "Noclip for worlds",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div>
 
-# VUdon - Noclip [![GitHub](https://img.shields.io/github/license/Varneon/VUdon-Noclip?color=blue&label=License&style=flat)](https://github.com/Varneon/VUdon-Noclip/blob/main/LICENSE) [![GitHub Repo stars](https://img.shields.io/github/stars/Varneon/VUdon-Noclip?style=flat&label=Stars)](https://github.com/Varneon/VUdon-Noclip/stargazers) [![GitHub all releases](https://img.shields.io/github/downloads/Varneon/VUdon-Noclip/total?color=blue&label=Downloads&style=flat)](https://github.com/Varneon/VUdon-Noclip/releases) [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/Varneon/VUdon-Noclip?color=blue&label=Release&sort=semver&style=flat)](https://github.com/Varneon/VUdon-Noclip/releases/latest)
+# [VUdon](https://github.com/Varneon/VUdon) - Noclip [![GitHub](https://img.shields.io/github/license/Varneon/VUdon-Noclip?color=blue&label=License&style=flat)](https://github.com/Varneon/VUdon-Noclip/blob/main/LICENSE) [![GitHub Repo stars](https://img.shields.io/github/stars/Varneon/VUdon-Noclip?style=flat&label=Stars)](https://github.com/Varneon/VUdon-Noclip/stargazers) [![GitHub all releases](https://img.shields.io/github/downloads/Varneon/VUdon-Noclip/total?color=blue&label=Downloads&style=flat)](https://github.com/Varneon/VUdon-Noclip/releases) [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/Varneon/VUdon-Noclip?color=blue&label=Release&sort=semver&style=flat)](https://github.com/Varneon/VUdon-Noclip/releases/latest)
 
 </div>
 


### PR DESCRIPTION
# Changes
- [VRChat Input Events](https://docs.vrchat.com/docs/input-events) are now used instead of `Input.GetAxisRaw` (1dff5a384dd97c4ff7702ccdae5963f3b20fb61e)
- Swapped VR input exponent to AnimationCurve (ff2daa8b95e5921da2f649568e8ff5106b43c437)
- Set DefaultExecutionOrder to -1000000000 (a2ad611b2b74a5c26b7cf40213acb9bdf59d2aeb)
- Added help URL that points to this repository's [wiki](https://github.com/Varneon/VUdon-Noclip/wiki/Settings) (4d57557ddfe916dcde591fee789ad06d77f07767)
- Improved package dependency version definitions (16095b50035ac6e5f11732ef6625a570f3a05f05, 17ee9b5d581284b4efb023e1e67feeac760910e9)